### PR TITLE
Added !calcskywars and !calcduels

### DIFF
--- a/src/minecraft/commands/DuelsStatsCommand.js
+++ b/src/minecraft/commands/DuelsStatsCommand.js
@@ -57,8 +57,11 @@ class DuelsStatsCommand extends minecraftCommand {
 
       hypixel.getPlayer(username).then((player) => {
         if (!duel) {
-          this.send(
-            `/gc [Duels] [${player.stats.duels.division}] ${username} Wins: ${player.stats.duels.wins} | CWS: ${player.stats.duels.winstreak} | BWS: ${player.stats.duels.bestWinstreak} | WLR: ${player.stats.duels.WLRatio}`
+          this.send(`/gc [Duels] [${player.stats.duels.division}] ${username
+            } | Wins: ${player.stats.duels.wins} WLR: ${player.stats.duels.WLRatio
+            } | Kills: ${player.stats.duels.kills} KDR: ${player.stats.duels.KDRatio
+            } | CWS: ${player.stats.duels.winstreak} BWS: ${player.stats.duels.bestWinstreak} WS: ${player.stats.duels.winstreak
+            }`
           );
         } else {
           if (
@@ -66,36 +69,28 @@ class DuelsStatsCommand extends minecraftCommand {
             Object?.keys(player?.stats?.duels?.[duel]).includes("1v1")
           ) {
             this.send(
-              `/gc [${duel.toUpperCase() ?? "Unknown"}] [${
-                player.stats.duels?.[duel]?.[
-                  Object.keys(player.stats.duels[duel])[0]
-                ]?.division ?? "Unknown"
-              }] ${username ?? 0} Wins: ${
-                player.stats.duels?.[duel]?.[
-                  Object.keys(player.stats.duels[duel])[0]
-                ]?.wins ?? 0
-              } | CWS: ${
-                player.stats.duels?.[duel]?.[
-                  Object.keys(player.stats.duels[duel])[0]
-                ]?.winstreak ?? 0
-              } | BWS: ${
-                player.stats.duels?.[duel]?.[
-                  Object.keys(player.stats.duels[duel])[0]
-                ]?.bestWinstreak ?? 0
-              } | WLR: ${
-                player.stats.duels?.[duel]?.[
-                  Object.keys(player.stats.duels[duel])[0]
-                ]?.WLRatio ?? 0
+              `/gc [${duel.toUpperCase() ?? "Unknown"}] [${player.stats.duels?.[duel]?.[
+                Object.keys(player.stats.duels[duel])[0]
+              ]?.division ?? "Unknown"
+              }] ${username ?? 0} Wins: ${player.stats.duels?.[duel]?.[
+                Object.keys(player.stats.duels[duel])[0]
+              ]?.wins ?? 0
+              } | CWS: ${player.stats.duels?.[duel]?.[
+                Object.keys(player.stats.duels[duel])[0]
+              ]?.winstreak ?? 0
+              } | BWS: ${player.stats.duels?.[duel]?.[
+                Object.keys(player.stats.duels[duel])[0]
+              ]?.bestWinstreak ?? 0
+              } | WLR: ${player.stats.duels?.[duel]?.[
+                Object.keys(player.stats.duels[duel])[0]
+              ]?.WLRatio ?? 0
               }`
             );
           } else {
             this.send(
-              `/gc [${duel.toUpperCase() ?? "Unknown"}] [${
-                player.stats.duels?.[duel]?.division ?? "Unknown"
-              }] ${username ?? 0} Wins: ${
-                player.stats.duels?.[duel]?.wins ?? 0
-              } | CWS: ${player.stats.duels?.[duel]?.winstreak ?? 0} | BWS: ${
-                player.stats.duels?.[duel]?.bestWinstreak ?? 0
+              `/gc [${duel.toUpperCase() ?? "Unknown"}] [${player.stats.duels?.[duel]?.division ?? "Unknown"
+              }] ${username ?? 0} Wins: ${player.stats.duels?.[duel]?.wins ?? 0
+              } | CWS: ${player.stats.duels?.[duel]?.winstreak ?? 0} | BWS: ${player.stats.duels?.[duel]?.bestWinstreak ?? 0
               } | WLR: ${player.stats.duels?.[duel]?.WLRatio ?? 0}`
             );
           }

--- a/src/minecraft/commands/SkyWarsStatsCommand.js
+++ b/src/minecraft/commands/SkyWarsStatsCommand.js
@@ -20,13 +20,13 @@ class SkywarsCommand extends minecraftCommand {
   async onCommand(username, message) {
     try {
       const msg = this.getArgs(message);
-      let hidden = false;
-      if (msg[0] == ["hidden", "hide", "h"]) hidden = true;
       if (msg[0]) username = msg[0];
       const player = await hypixel.getPlayer(username);
 
-      this.send(
-        `${hidden ? "/oc" : "/gc"} [${player.stats.skywars.level}✫] ${player.nickname} Kills: ${player.stats.skywars.kills} KDR:${player.stats.skywars.KDRatio} | Wins: ${player.stats.skywars.wins} WLR:${player.stats.skywars.WLRatio}| WS:${player.stats.skywars.winstreak}`
+      this.send(`/gc [${player.stats.skywars.level}✫] ${player.nickname
+        } | Kills: ${player.stats.skywars.kills} KDR: ${player.stats.skywars.KDRatio
+        } | Wins: ${player.stats.skywars.wins} WLR: ${player.stats.skywars.WLRatio
+        } | WS: ${player.stats.skywars.winstreak}`
       );
       fetch(
         `${config.api.pixelicAPI}/player/register?key=${config.api.pixelicKey}&uuid=${player.uuid}`,

--- a/src/minecraft/commands/calculateDuelsCommand.js
+++ b/src/minecraft/commands/calculateDuelsCommand.js
@@ -5,7 +5,7 @@ class CalculateDuelsCommand extends minecraftCommand {
     constructor(minecraft) {
         super(minecraft);
 
-        this.name = "calcsw";
+        this.name = "calcduels";
         this.aliases = [];
         this.description = "Alows you to calc how close you are to the next wlr/kd";
         this.options = [];

--- a/src/minecraft/commands/calculateDuelsCommand.js
+++ b/src/minecraft/commands/calculateDuelsCommand.js
@@ -1,0 +1,51 @@
+const minecraftCommand = require("../../contracts/minecraftCommand.js");
+const hypixel = require("../../contracts/API/HypixelRebornAPI.js");
+
+class CalculateDuelsCommand extends minecraftCommand {
+    constructor(minecraft) {
+        super(minecraft);
+
+        this.name = "calcsw";
+        this.aliases = [];
+        this.description = "Alows you to calc how close you are to the next wlr/kd";
+        this.options = [];
+    }
+
+    async onCommand(username, message) {
+        try {
+            // could be cleaner but it works
+            const msg = this.getArgs(message);
+            let type = null;
+            let target = null;
+
+            // Todo add support for someones username and a gamemode 
+            if (['kd', 'wlr'].includes(msg[0])) type = msg[0];
+            if (msg[1]) target = msg[1];
+
+            var player = await hypixel.getPlayer(username);
+
+            if (type == 'kd') {
+                if (target < player.stats.duels.KDRatio) { this.send(`/gc You already have a higher kd than ${target}`) }
+                else {
+                    var kills = player.stats.duels.kills
+                    var deaths = player.stats.duels.deaths
+                    var neededKills = (target * deaths) - kills;
+                    this.send(`/gc You need ${neededKills} kills with 0  deaths to reach ${target} kd`);
+                }
+            } else if (type == 'wlr') {
+                if (target < player.stats.duels.WLRatio) { this.send(`/gc You already have a higher wlr than ${target}`) }
+                else {
+                    var wins = player.stats.duels.wins;
+                    var losses = player.stats.duels.losses;
+                    var neededWins = (target * losses) - wins;
+                    this.send(`/gc You need ${neededWins} wins with 0 losses to reach ${target} wlr`);
+                }
+            }
+        } catch (error) {
+            console.log(error);
+            this.send("/gc Something went wrong..");
+        }
+    }
+}
+
+module.exports = CalculateDuelsCommand;

--- a/src/minecraft/commands/calculateSkywarsCommand.js
+++ b/src/minecraft/commands/calculateSkywarsCommand.js
@@ -1,0 +1,51 @@
+const minecraftCommand = require("../../contracts/minecraftCommand.js");
+const hypixel = require("../../contracts/API/HypixelRebornAPI.js");
+
+class CalculateDuelsCommand extends minecraftCommand {
+    constructor(minecraft) {
+        super(minecraft);
+
+        this.name = "calcduels";
+        this.aliases = [];
+        this.description = "Alows you to calc how close you are to the next wlr/kd";
+        this.options = [];
+    }
+
+    async onCommand(username, message) {
+        try {
+            // could be cleaner but it works
+            const msg = this.getArgs(message);
+            let type = null;
+            let target = null;
+
+            // Todo add support for someones username and a gamemode 
+            if (['kd', 'wlr'].includes(msg[0])) type = msg[0];
+            if (msg[1]) target = msg[1];
+
+            var player = await hypixel.getPlayer(username);
+
+            if (type == 'kd') {
+                if (target < player.stats.duels.KDRatio) { this.send(`/gc You already have a higher kd than ${target}`) }
+                else {
+                    var kills = player.stats.duels.kills
+                    var deaths = player.stats.duels.deaths
+                    var neededKills = (target * deaths) - kills;
+                    this.send(`/gc You need ${neededKills} kills with 0  deaths to reach ${target} kd`);
+                }
+            } else if (type == 'wlr') {
+                if (target < player.stats.duels.WLRatio) { this.send(`/gc You already have a higher wlr than ${target}`) }
+                else {
+                    var wins = player.stats.duels.wins;
+                    var losses = player.stats.duels.losses;
+                    var neededWins = (target * losses) - wins;
+                    this.send(`/gc You need ${neededWins} wins with 0 losses to reach ${target} wlr`);
+                }
+            }
+        } catch (error) {
+            console.log(error);
+            this.send("/gc Something went wrong..");
+        }
+    }
+}
+
+module.exports = CalculateDuelsCommand;

--- a/src/minecraft/commands/calculateSkywarsCommand.js
+++ b/src/minecraft/commands/calculateSkywarsCommand.js
@@ -1,12 +1,12 @@
 const minecraftCommand = require("../../contracts/minecraftCommand.js");
 const hypixel = require("../../contracts/API/HypixelRebornAPI.js");
 
-class CalculateDuelsCommand extends minecraftCommand {
+class CalculatSkywarsCommand extends minecraftCommand {
     constructor(minecraft) {
         super(minecraft);
 
-        this.name = "calcduels";
-        this.aliases = [];
+        this.name = "calcskywars";
+        this.aliases = ["calcsw"];
         this.description = "Alows you to calc how close you are to the next wlr/kd";
         this.options = [];
     }
@@ -25,18 +25,18 @@ class CalculateDuelsCommand extends minecraftCommand {
             var player = await hypixel.getPlayer(username);
 
             if (type == 'kd') {
-                if (target < player.stats.duels.KDRatio) { this.send(`/gc You already have a higher kd than ${target}`) }
+                if (target < player.stats.skywars.KDRatio) { this.send(`/gc You already have a higher kd than ${target}`) }
                 else {
-                    var kills = player.stats.duels.kills
-                    var deaths = player.stats.duels.deaths
+                    var kills = player.stats.skywars.kills
+                    var deaths = player.stats.skywars.deaths
                     var neededKills = (target * deaths) - kills;
                     this.send(`/gc You need ${neededKills} kills with 0  deaths to reach ${target} kd`);
                 }
             } else if (type == 'wlr') {
-                if (target < player.stats.duels.WLRatio) { this.send(`/gc You already have a higher wlr than ${target}`) }
+                if (target < player.stats.skywars.WLRatio) { this.send(`/gc You already have a higher wlr than ${target}`) }
                 else {
-                    var wins = player.stats.duels.wins;
-                    var losses = player.stats.duels.losses;
+                    var wins = player.stats.skywars.wins;
+                    var losses = player.stats.skywars.losses;
                     var neededWins = (target * losses) - wins;
                     this.send(`/gc You need ${neededWins} wins with 0 losses to reach ${target} wlr`);
                 }
@@ -48,4 +48,4 @@ class CalculateDuelsCommand extends minecraftCommand {
     }
 }
 
-module.exports = CalculateDuelsCommand;
+module.exports = CalculatSkywarsCommand;


### PR DESCRIPTION
Added !calcsw and !calcduels

Usage: `!calcsw <type> <number>`
Example: `!calcsw kd 1`
Resualt: [https://i.imgur.com/h08dsZs.png](https://i.imgur.com/h08dsZs.png)
All types: kd and wlr - they must be lowercase to work should make a fix for that soon

Usage: `!calcduels <type> <number>`
Example: `!calcduels kd 1`
Resualt: [https://i.imgur.com/HqHxbLd.png](https://i.imgur.com/HqHxbLd.png)
All types: kd and wlr - they must be lowercase to work should make a fix for that soon